### PR TITLE
Pr/fix npe

### DIFF
--- a/src/main/java/com/nordstrom/automation/junit/AtomicTest.java
+++ b/src/main/java/com/nordstrom/automation/junit/AtomicTest.java
@@ -21,14 +21,14 @@ import org.junit.runners.model.TestClass;
  */
 @Ignore
 @SuppressWarnings("all")
-public class AtomicTest {
+public class AtomicTest<T> {
     private final Object runner;
     private final Description description;
-    private final FrameworkMethod identity;
-    private final List<FrameworkMethod> particles;
+    private final T identity;
+    private final List<T> particles;
     private Throwable thrown;
 
-    public AtomicTest(Object runner, FrameworkMethod identity) {
+    public AtomicTest(Object runner, T identity) {
         this.runner = runner;
         this.identity = identity;
         this.description = invoke(runner, "describeChild", identity);
@@ -58,7 +58,7 @@ public class AtomicTest {
      * 
      * @return core method associated with this atomic test
      */
-    public FrameworkMethod getIdentity() {
+    public T getIdentity() {
         return identity;
     }
     
@@ -67,7 +67,7 @@ public class AtomicTest {
      * 
      * @return list of methods that compose this atomic test
      */
-    public List<FrameworkMethod> getParticles() {
+    public List<T> getParticles() {
         return particles;
     }
 

--- a/src/main/java/com/nordstrom/automation/junit/AtomicTest.java
+++ b/src/main/java/com/nordstrom/automation/junit/AtomicTest.java
@@ -11,7 +11,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.Description;
-import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.TestClass;
 
 /**
@@ -101,10 +100,10 @@ public class AtomicTest<T> {
     /**
      * Determine if this atomic test includes the specified method.
      * 
-     * @param method {@link FrameworkMethod} object
+     * @param method method object
      * @return {@code true} if this atomic test includes the specified method; otherwise {@code false}
      */
-    public boolean includes(FrameworkMethod method) {
+    public boolean includes(T method) {
         return particles.contains(method);
     }
     

--- a/src/main/java/com/nordstrom/automation/junit/LifecycleHooks.java
+++ b/src/main/java/com/nordstrom/automation/junit/LifecycleHooks.java
@@ -194,7 +194,7 @@ public class LifecycleHooks {
      * @param runner JUnit class runner
      * @return {@link AtomicTest} object (may be {@code null})
      */
-    public static AtomicTest getAtomicTestOf(Object runner) {
+    public static AtomicTest<?> getAtomicTestOf(Object runner) {
         return RunAnnouncer.getAtomicTestOf(runner);
     }
     

--- a/src/main/java/com/nordstrom/automation/junit/LifecycleHooks.java
+++ b/src/main/java/com/nordstrom/automation/junit/LifecycleHooks.java
@@ -194,7 +194,7 @@ public class LifecycleHooks {
      * @param runner JUnit class runner
      * @return {@link AtomicTest} object (may be {@code null})
      */
-    public static AtomicTest<?> getAtomicTestOf(Object runner) {
+    public static <T> AtomicTest<T> getAtomicTestOf(Object runner) {
         return RunAnnouncer.getAtomicTestOf(runner);
     }
     

--- a/src/main/java/com/nordstrom/automation/junit/RunAnnouncer.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunAnnouncer.java
@@ -134,17 +134,17 @@ public class RunAnnouncer<T> extends RunListener {
     /**
      * Get reference to an instance of the specified watcher type.
      * 
-     * @param <T> watcher type
+     * @param <W> watcher type
      * @param watcherType watcher type
      * @return optional watcher instance
      */
     @SuppressWarnings("unchecked")
-    static <T extends JUnitWatcher> Optional<T> getAttachedWatcher(Class<T> watcherType) {
+    static <W extends JUnitWatcher> Optional<W> getAttachedWatcher(Class<W> watcherType) {
         if (RunWatcher.class.isAssignableFrom(watcherType)) {
             synchronized(runWatcherLoader) {
                 for (RunWatcher watcher : runWatcherLoader) {
                     if (watcher.getClass() == watcherType) {
-                        return Optional.of((T) watcher);
+                        return Optional.of((W) watcher);
                     }
                 }
             }

--- a/src/main/java/com/nordstrom/automation/junit/RunAnnouncer.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunAnnouncer.java
@@ -8,16 +8,15 @@ import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
-import org.junit.runners.model.FrameworkMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 
-public class RunAnnouncer extends RunListener {
+public class RunAnnouncer<T> extends RunListener {
     
     private static final ServiceLoader<RunWatcher> runWatcherLoader;
-    private static final Map<Object, AtomicTest> RUNNER_TO_ATOMICTEST = new ConcurrentHashMap<>();
+    private static final Map<Object, AtomicTest<?>> RUNNER_TO_ATOMICTEST = new ConcurrentHashMap<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(RunAnnouncer.class);
     
     static {
@@ -30,7 +29,7 @@ public class RunAnnouncer extends RunListener {
     @Override
     public void testStarted(Description description) throws Exception {
         LOGGER.debug("testStarted: {}", description);
-        AtomicTest atomicTest = getAtomicTestOf(description);
+        AtomicTest<T> atomicTest = getAtomicTestOf(description);
         synchronized(runWatcherLoader) {
             for (RunWatcher watcher : runWatcherLoader) {
                 watcher.testStarted(atomicTest);
@@ -44,7 +43,7 @@ public class RunAnnouncer extends RunListener {
     @Override
     public void testFinished(Description description) throws Exception {
         LOGGER.debug("testFinished: {}", description);
-        AtomicTest atomicTest = getAtomicTestOf(description);
+        AtomicTest<T> atomicTest = getAtomicTestOf(description);
         synchronized(runWatcherLoader) {
             for (RunWatcher watcher : runWatcherLoader) {
                 watcher.testFinished(atomicTest);
@@ -58,7 +57,7 @@ public class RunAnnouncer extends RunListener {
     @Override
     public void testFailure(Failure failure) throws Exception {
         LOGGER.debug("testFailure: {}", failure);
-        AtomicTest atomicTest = setTestFailure(failure);
+        AtomicTest<T> atomicTest = setTestFailure(failure);
         synchronized(runWatcherLoader) {
             for (RunWatcher watcher : runWatcherLoader) {
                 watcher.testFailure(atomicTest, failure.getException());
@@ -72,7 +71,7 @@ public class RunAnnouncer extends RunListener {
     @Override
     public void testAssumptionFailure(Failure failure) {
         LOGGER.debug("testAssumptionFailure: {}", failure);
-        AtomicTest atomicTest = setTestFailure(failure);
+        AtomicTest<T> atomicTest = setTestFailure(failure);
         synchronized(runWatcherLoader) {
             for (RunWatcher watcher : runWatcherLoader) {
                 watcher.testAssumptionFailure(atomicTest, (AssumptionViolatedException) failure.getException());
@@ -86,7 +85,7 @@ public class RunAnnouncer extends RunListener {
     @Override
     public void testIgnored(Description description) throws Exception {
         LOGGER.debug("testIgnored: {}", description);
-        AtomicTest atomicTest = getAtomicTestOf(description);
+        AtomicTest<T> atomicTest = getAtomicTestOf(description);
         synchronized(runWatcherLoader) {
             for (RunWatcher watcher : runWatcherLoader) {
                 watcher.testIgnored(atomicTest);
@@ -95,13 +94,15 @@ public class RunAnnouncer extends RunListener {
     }
     
     /**
-     * Create new atomic test object for the specified description.
+     * Create new atomic test object for the specified runner/child pair.
      * 
-     * @param description {@link Description} object
+     * @param <T> type of children associated with the specified runner
+     * @param runner parent runner
+     * @param identity identity for this atomic test
      * @return {@link AtomicTest} object
      */
-    static AtomicTest newAtomicTest(Object runner, FrameworkMethod method) {
-        AtomicTest atomicTest = new AtomicTest(runner, method);
+    static <T> AtomicTest<T> newAtomicTest(Object runner, T identity) {
+        AtomicTest<T> atomicTest = new AtomicTest<>(runner, identity);
         RUNNER_TO_ATOMICTEST.put(runner, atomicTest);
         RUNNER_TO_ATOMICTEST.put(atomicTest.getDescription(), atomicTest);
         return atomicTest;
@@ -113,8 +114,9 @@ public class RunAnnouncer extends RunListener {
      * @param testKey JUnit class runner or method description
      * @return {@link AtomicTest} object (may be {@code null})
      */
-    static AtomicTest getAtomicTestOf(Object testKey) {
-        return RUNNER_TO_ATOMICTEST.get(testKey);
+    @SuppressWarnings("unchecked")
+    static <T> AtomicTest<T> getAtomicTestOf(Object testKey) {
+        return (AtomicTest<T>) RUNNER_TO_ATOMICTEST.get(testKey);
     }
     
     /**
@@ -123,8 +125,8 @@ public class RunAnnouncer extends RunListener {
      * @param failure {@link Failure} object
      * @return {@link AtomicTest} object
      */
-    private static AtomicTest setTestFailure(Failure failure) {
-        AtomicTest atomicTest = getAtomicTestOf(Run.getThreadRunner());
+    private static <T> AtomicTest<T> setTestFailure(Failure failure) {
+        AtomicTest<T> atomicTest = getAtomicTestOf(Run.getThreadRunner());
         atomicTest.setThrowable(failure.getException());
         return atomicTest;
     }

--- a/src/main/java/com/nordstrom/automation/junit/RunAnnouncer.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunAnnouncer.java
@@ -15,6 +15,7 @@ import com.google.common.base.Optional;
 
 public class RunAnnouncer<T> extends RunListener {
     
+    @SuppressWarnings("rawtypes")
     private static final ServiceLoader<RunWatcher> runWatcherLoader;
     private static final Map<Object, AtomicTest<?>> RUNNER_TO_ATOMICTEST = new ConcurrentHashMap<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(RunAnnouncer.class);
@@ -27,11 +28,12 @@ public class RunAnnouncer<T> extends RunListener {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void testStarted(Description description) throws Exception {
         LOGGER.debug("testStarted: {}", description);
         AtomicTest<T> atomicTest = getAtomicTestOf(description);
         synchronized(runWatcherLoader) {
-            for (RunWatcher watcher : runWatcherLoader) {
+            for (RunWatcher<T> watcher : runWatcherLoader) {
                 watcher.testStarted(atomicTest);
             }
         }
@@ -41,11 +43,12 @@ public class RunAnnouncer<T> extends RunListener {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void testFinished(Description description) throws Exception {
         LOGGER.debug("testFinished: {}", description);
         AtomicTest<T> atomicTest = getAtomicTestOf(description);
         synchronized(runWatcherLoader) {
-            for (RunWatcher watcher : runWatcherLoader) {
+            for (RunWatcher<T> watcher : runWatcherLoader) {
                 watcher.testFinished(atomicTest);
             }
         }
@@ -55,11 +58,12 @@ public class RunAnnouncer<T> extends RunListener {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void testFailure(Failure failure) throws Exception {
         LOGGER.debug("testFailure: {}", failure);
         AtomicTest<T> atomicTest = setTestFailure(failure);
         synchronized(runWatcherLoader) {
-            for (RunWatcher watcher : runWatcherLoader) {
+            for (RunWatcher<T> watcher : runWatcherLoader) {
                 watcher.testFailure(atomicTest, failure.getException());
             }
         }
@@ -69,11 +73,12 @@ public class RunAnnouncer<T> extends RunListener {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void testAssumptionFailure(Failure failure) {
         LOGGER.debug("testAssumptionFailure: {}", failure);
         AtomicTest<T> atomicTest = setTestFailure(failure);
         synchronized(runWatcherLoader) {
-            for (RunWatcher watcher : runWatcherLoader) {
+            for (RunWatcher<T> watcher : runWatcherLoader) {
                 watcher.testAssumptionFailure(atomicTest, (AssumptionViolatedException) failure.getException());
             }
         }
@@ -83,11 +88,12 @@ public class RunAnnouncer<T> extends RunListener {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void testIgnored(Description description) throws Exception {
         LOGGER.debug("testIgnored: {}", description);
         AtomicTest<T> atomicTest = getAtomicTestOf(description);
         synchronized(runWatcherLoader) {
-            for (RunWatcher watcher : runWatcherLoader) {
+            for (RunWatcher<T> watcher : runWatcherLoader) {
                 watcher.testIgnored(atomicTest);
             }
         }
@@ -142,7 +148,7 @@ public class RunAnnouncer<T> extends RunListener {
     static <W extends JUnitWatcher> Optional<W> getAttachedWatcher(Class<W> watcherType) {
         if (RunWatcher.class.isAssignableFrom(watcherType)) {
             synchronized(runWatcherLoader) {
-                for (RunWatcher watcher : runWatcherLoader) {
+                for (RunWatcher<?> watcher : runWatcherLoader) {
                     if (watcher.getClass() == watcherType) {
                         return Optional.of((W) watcher);
                     }

--- a/src/main/java/com/nordstrom/automation/junit/RunChild.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunChild.java
@@ -67,7 +67,7 @@ public class RunChild {
                 LifecycleHooks.callProxy(proxy);
             }
         } catch (NoSuchMethodException e) {
-            
+            LifecycleHooks.callProxy(proxy);
         } finally {
             Run.popThreadRunner();
         }

--- a/src/main/java/com/nordstrom/automation/junit/RunChild.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunChild.java
@@ -49,14 +49,14 @@ public class RunChild {
         
         try {
             Run.pushThreadRunner(runner);
+            RunAnnouncer.newAtomicTest(runner, child);
+            
             if (child instanceof FrameworkMethod) {
                 FrameworkMethod method = (FrameworkMethod) child;
                 
                 applyTimeout(method);
                 int count = RetryHandler.getMaxRetry(runner, method);
                 boolean isIgnored = (null != method.getAnnotation(Ignore.class));
-                
-                RunAnnouncer.newAtomicTest(runner, method);
                 
                 if (count == 0) {
                     LifecycleHooks.callProxy(proxy);
@@ -66,6 +66,8 @@ public class RunChild {
             } else {
                 LifecycleHooks.callProxy(proxy);
             }
+        } catch (NoSuchMethodException e) {
+            
         } finally {
             Run.popThreadRunner();
         }

--- a/src/main/java/com/nordstrom/automation/junit/RunWatcher.java
+++ b/src/main/java/com/nordstrom/automation/junit/RunWatcher.java
@@ -5,21 +5,21 @@ import org.junit.internal.AssumptionViolatedException;
 /**
  * This interface defines the methods implemented by JUnit run watchers.
  */
-public interface RunWatcher extends JUnitWatcher {
+public interface RunWatcher<T> extends JUnitWatcher {
 
     /**
      * Called when an atomic test is about to be started.
      *
      * @param atomicTest {@link AtomicTest} object for this atomic test
      */
-    public void testStarted(AtomicTest atomicTest);
+    public void testStarted(AtomicTest<T> atomicTest);
 
     /**
      * Called when an atomic test has finished, whether the test succeeds or fails.
      *
      * @param atomicTest {@link AtomicTest} object for this atomic test
      */
-    public void testFinished(AtomicTest atomicTest);
+    public void testFinished(AtomicTest<T> atomicTest);
     
     /**
      * Called when an atomic test fails.
@@ -27,7 +27,7 @@ public interface RunWatcher extends JUnitWatcher {
      * @param atomicTest {@link AtomicTest} object for this atomic test
      * @param thrown exception thrown by method
      */
-    public void testFailure(AtomicTest atomicTest, Throwable thrown);
+    public void testFailure(AtomicTest<T> atomicTest, Throwable thrown);
 
     /**
      * Called when an atomic test flags that it assumes a condition that is false
@@ -35,13 +35,13 @@ public interface RunWatcher extends JUnitWatcher {
      * @param atomicTest {@link AtomicTest} object for this atomic test
      * @param thrown {@link AssumptionViolatedException} thrown by method
      */
-    public void testAssumptionFailure(AtomicTest atomicTest, AssumptionViolatedException thrown);
+    public void testAssumptionFailure(AtomicTest<T> atomicTest, AssumptionViolatedException thrown);
     
     /**
      * Called when a test will not be run, generally because a test method is annotated with {@link org.junit.Ignore}.
      * 
      * @param atomicTest {@link AtomicTest} object for this atomic test
      */
-    public void testIgnored(AtomicTest atomicTest);
+    public void testIgnored(AtomicTest<T> atomicTest);
     
 }


### PR DESCRIPTION
Resolved #50 
I hadn't supported the generic type of the ParentRunner properly, locking the implementation into FrameworkMethod. This PR fixes that issue.